### PR TITLE
Fix upstream regression introduced by moving docker entrypoint away from root

### DIFF
--- a/balena-entrypoint.sh
+++ b/balena-entrypoint.sh
@@ -114,5 +114,5 @@ fi
 export PGDATA="${PGDATA}/${TARGET_VERSION}"
 
 # run the existing Postgres entrypoint script...
-. /docker-entrypoint.sh
+. /usr/local/bin/docker-entrypoint.sh
 _main "$@"


### PR DESCRIPTION
https://github.com/docker-library/postgres/pull/852/files#diff-be72594b81f7ffc23a3fd959ffa1f0e17c8043c1c1348b176f270f815d78d6cdL186

Change-type: patch